### PR TITLE
added softnanotools dependency into setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,8 @@ setuptools.setup(
     package_data = {'starpolymers' : ['io/input_files/*.in']},
     include_package_data=True,
     version=versioneer.get_version(),
-    cmdclass=versioneer.get_cmdclass(),
+    cmdclass=versioneer.get_cmdclass(),    
+    install_requires=[
+          'softnanotools',
+      ],
 )


### PR DESCRIPTION
Installing manually via `setup.py` did not install the `softnanotools` utilised in the `starpolymers` package.